### PR TITLE
Add UUID/ULID feature parity

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,7 +1,12 @@
 name: Fix PHP code style issues
 
 on:
+  pull_request:
+    paths:
+      - '**.php'
   push:
+    branches:
+      - main
     paths:
       - '**.php'
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,7 +1,14 @@
 name: PHPStan
 
 on:
+  pull_request:
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
+      - '.github/workflows/phpstan.yml'
   push:
+    branches:
+      - main
     paths:
       - '**.php'
       - 'phpstan.neon.dist'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,16 @@
 name: run-tests
 
 on:
+  pull_request:
+    paths:
+      - '**.php'
+      - '.github/workflows/run-tests.yml'
+      - 'phpunit.xml.dist'
+      - 'composer.json'
+      - 'composer.lock'
   push:
+    branches:
+      - main
     paths:
       - '**.php'
       - '.github/workflows/run-tests.yml'

--- a/src/LaravelHashId.php
+++ b/src/LaravelHashId.php
@@ -2,8 +2,16 @@
 
 namespace Bretterer\LaravelHashId;
 
+use Closure;
+
 class LaravelHashId
 {
+    protected static ?Closure $customFactory = null;
+
+    protected static ?array $sequence = null;
+
+    protected static int $sequenceIndex = 0;
+
     /**
      * Generate a collision-resistant hashId.
      *
@@ -11,6 +19,14 @@ class LaravelHashId
      */
     public function generate(int $length = 16): string
     {
+        if (static::$sequence !== null) {
+            return static::nextInSequence();
+        }
+
+        if (static::$customFactory !== null) {
+            return (static::$customFactory)($length);
+        }
+
         // Use random_bytes for cryptographic randomness
         $bytes = random_bytes($length);
         // Encode as base62 for compactness and URL safety
@@ -60,5 +76,86 @@ class LaravelHashId
         }
 
         return $base62 ?: '0';
+    }
+
+    /**
+     * Validate that a value is a valid hashId.
+     */
+    public static function isValid(string $value, ?int $length = null): bool
+    {
+        if ($length !== null) {
+            return (bool) preg_match('/^[0-9A-Za-z]{'.$length.'}$/', $value);
+        }
+
+        return (bool) preg_match('/^[0-9A-Za-z]+$/', $value);
+    }
+
+    /**
+     * Always return the same hashId.
+     *
+     * @return string The frozen hashId value
+     */
+    public static function freeze(?Closure $callback = null): string
+    {
+        $frozenValue = (new self)->generate();
+
+        static::createUsing(fn () => $frozenValue);
+
+        if ($callback !== null) {
+            try {
+                $callback($frozenValue);
+            } finally {
+                static::createNormally();
+            }
+        }
+
+        return $frozenValue;
+    }
+
+    /**
+     * Set a custom factory for generating hashIds.
+     */
+    public static function createUsing(?callable $factory = null): void
+    {
+        static::$customFactory = $factory !== null ? $factory(...) : null;
+    }
+
+    /**
+     * Generate hashIds from a predefined sequence.
+     */
+    public static function createUsingSequence(array $sequence, ?callable $whenMissing = null): void
+    {
+        static::$sequence = $sequence;
+        static::$sequenceIndex = 0;
+        static::$customFactory = $whenMissing !== null ? $whenMissing(...) : null;
+    }
+
+    /**
+     * Reset hashId generation to normal behavior.
+     */
+    public static function createNormally(): void
+    {
+        static::$customFactory = null;
+        static::$sequence = null;
+        static::$sequenceIndex = 0;
+    }
+
+    /**
+     * Get the next value from the sequence.
+     */
+    protected static function nextInSequence(): string
+    {
+        if (static::$sequenceIndex < count(static::$sequence)) {
+            return static::$sequence[static::$sequenceIndex++];
+        }
+
+        // Sequence exhausted — fall back to custom factory or normal generation
+        static::$sequence = null;
+
+        if (static::$customFactory !== null) {
+            return (static::$customFactory)(16);
+        }
+
+        return (new self)->generate();
     }
 }

--- a/src/LaravelHashIdServiceProvider.php
+++ b/src/LaravelHashIdServiceProvider.php
@@ -6,10 +6,18 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\ColumnDefinition;
 use Illuminate\Database\Schema\ForeignIdColumnDefinition;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class LaravelHashIdServiceProvider extends ServiceProvider
 {
     public function boot(): void
+    {
+        $this->registerBlueprintMacros();
+        $this->registerValidationRules();
+        $this->registerStrMacros();
+    }
+
+    protected function registerBlueprintMacros(): void
     {
         Blueprint::macro('hashId', fn (string $column = 'id', int $length = 24): ColumnDefinition => $this->char($column, $length));
 
@@ -20,5 +28,39 @@ class LaravelHashIdServiceProvider extends ServiceProvider
                 'name' => $column,
                 'length' => $length,
             ])));
+
+        Blueprint::macro('hashIdMorphs', function (string $name, ?string $indexName = null) {
+            /** @var Blueprint $this */
+            $this->string("{$name}_type");
+            $this->char("{$name}_id", 24);
+            $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        });
+
+        Blueprint::macro('nullableHashIdMorphs', function (string $name, ?string $indexName = null) {
+            /** @var Blueprint $this */
+            $this->string("{$name}_type")->nullable();
+            $this->char("{$name}_id", 24)->nullable();
+            $this->index(["{$name}_type", "{$name}_id"], $indexName);
+        });
+    }
+
+    protected function registerStrMacros(): void
+    {
+        Str::macro('hashId', fn (int $length = 16): string => (new LaravelHashId)->generate($length));
+
+        Str::macro('isHashId', fn (string $value, ?int $length = null): bool => LaravelHashId::isValid($value, $length));
+    }
+
+    protected function registerValidationRules(): void
+    {
+        $this->app['validator']->extend('hashid', function ($attribute, $value, $parameters) {
+            if (! is_string($value)) {
+                return false;
+            }
+
+            $length = ! empty($parameters[0]) ? (int) $parameters[0] : null;
+
+            return LaravelHashId::isValid($value, $length);
+        }, 'The :attribute must be a valid HashId.');
     }
 }

--- a/src/Traits/HasHashIds.php
+++ b/src/Traits/HasHashIds.php
@@ -16,12 +16,17 @@ trait HasHashIds
         return '';
     }
 
+    public function hashIdLength(): int
+    {
+        return 16;
+    }
+
     /**
      * Generate a new unique key for the model.
      */
     public function newUniqueId(): string
     {
-        $hashId = (new LaravelHashId)->generate(16);
+        $hashId = (new LaravelHashId)->generate($this->hashIdLength());
 
         return empty($this->idPrefix()) ? $hashId : $this->idPrefix().'_'.$hashId;
     }
@@ -37,9 +42,10 @@ trait HasHashIds
 
         $value = collect(explode('_', $value))->last();
 
-        // Validate it's a 16-character base62 string
+        $length = $this->hashIdLength();
+
         return is_string($value)
-            && mb_strlen($value) === 16
-            && preg_match('/^[0-9A-Za-z]{16}$/', $value) === 1;
+            && mb_strlen($value) === $length
+            && preg_match('/^[0-9A-Za-z]{'.$length.'}$/', $value) === 1;
     }
 }

--- a/tests/ConfigurableLengthTest.php
+++ b/tests/ConfigurableLengthTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Bretterer\LaravelHashId\LaravelHashId;
 use Bretterer\LaravelHashId\Traits\HasHashIds;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
@@ -57,7 +58,7 @@ describe('Configurable HashId length', function () {
             }
         };
 
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $valid = $generator->generate(12);
         expect($trait->test($valid))->toBeTrue();
 

--- a/tests/ConfigurableLengthTest.php
+++ b/tests/ConfigurableLengthTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Bretterer\LaravelHashId\Traits\HasHashIds;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+
+class ShortHashIdUser extends Model
+{
+    use HasHashIds;
+
+    public $timestamps = false;
+
+    protected $table = 'short_hash_users';
+
+    protected $guarded = [];
+
+    protected $primaryKey = 'id';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    public function hashIdLength(): int
+    {
+        return 12;
+    }
+}
+
+describe('Configurable HashId length', function () {
+    beforeEach(function () {
+        Schema::dropIfExists('short_hash_users');
+        Schema::create('short_hash_users', function ($table) {
+            $table->hashId('id', 12)->primary();
+            $table->string('name');
+        });
+    });
+
+    it('generates hashId with custom length', function () {
+        $user = ShortHashIdUser::create(['name' => 'Alice']);
+        expect($user->id)->toMatch('/^[0-9A-Za-z]{12}$/');
+        expect(strlen($user->id))->toBe(12);
+    });
+
+    it('validates hashId with custom length', function () {
+        $trait = new class
+        {
+            use HasHashIds;
+
+            public function hashIdLength(): int
+            {
+                return 12;
+            }
+
+            public function test($value)
+            {
+                return $this->isValidUniqueId($value);
+            }
+        };
+
+        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $valid = $generator->generate(12);
+        expect($trait->test($valid))->toBeTrue();
+
+        // 16-char hashId should fail validation for a 12-length model
+        $tooLong = $generator->generate(16);
+        expect($trait->test($tooLong))->toBeFalse();
+    });
+
+    it('retrieves model by custom-length hashId', function () {
+        $user = ShortHashIdUser::create(['name' => 'Bob']);
+        $found = ShortHashIdUser::find($user->id);
+        expect($found)->not->toBeNull();
+        expect($found->name)->toBe('Bob');
+    });
+});

--- a/tests/HasHashIdsExtraTest.php
+++ b/tests/HasHashIdsExtraTest.php
@@ -1,10 +1,12 @@
 <?php
 
+use Bretterer\LaravelHashId\Traits\HasHashIds;
+
 describe('HasHashIds uncovered line', function () {
     it('isValidUniqueId returns false for non-string', function () {
         $trait = new class
         {
-            use \Bretterer\LaravelHashId\Traits\HasHashIds;
+            use HasHashIds;
 
             public function test($value)
             {

--- a/tests/HashIdTest.php
+++ b/tests/HashIdTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Bretterer\LaravelHashId\LaravelHashId;
 use Bretterer\LaravelHashId\Traits\HasHashIds;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
@@ -123,7 +124,7 @@ describe('HashId trait validation', function () {
                 return $this->isValidUniqueId($value);
             }
         };
-        $valid = (new \Bretterer\LaravelHashId\LaravelHashId)->generate(16);
+        $valid = (new LaravelHashId)->generate(16);
         expect($trait->test($valid))->toBeTrue();
     });
 
@@ -145,21 +146,21 @@ describe('HashId trait validation', function () {
 
 describe('HashId generator', function () {
     it('generates collision-resistant hashIds', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $hashId = $generator->generate(16);
         expect($hashId)->toMatch('/^[0-9A-Za-z]{16}$/');
         expect(strlen($hashId))->toBe(16);
     });
 
     it('generates hashId from value with salt', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $hashId = $generator->generateFromValue('test', 'salt', 16);
         expect($hashId)->toMatch('/^[0-9A-Za-z]{16}$/');
         expect(strlen($hashId))->toBe(16);
     });
 
     test('generates different ids on multiple calls', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $id1 = $generator->generate(16);
         $id2 = $generator->generate(16);
         expect($id1)->not->toBe($id2);

--- a/tests/LaravelHashIdExtraTest.php
+++ b/tests/LaravelHashIdExtraTest.php
@@ -1,41 +1,43 @@
 <?php
 
+use Bretterer\LaravelHashId\LaravelHashId;
+
 describe('LaravelHashId uncovered lines', function () {
     it('base62Encode returns "0" for zero bytes', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $result = $generator->base62Encode("\x00\x00\x00");
         expect($result)->toBe('0');
     });
 
     it('base62Encode returns correct base62 for known value', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         // 1 byte: 0x01 should be '1'
         $result = $generator->base62Encode("\x01");
         expect($result)->toBe('1');
     });
 
     it('generate pads hashId if too short', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         // Use a length that will likely result in a short base62 string
         $hashId = $generator->generate(1); // base62Encode of 1 byte is usually 1 char
         expect(strlen($hashId))->toBe(1);
     });
 
     it('generate truncates hashId if too long', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         // Use a length that will result in a long base62 string
         $hashId = $generator->generate(64); // base62Encode of 64 bytes is long
         expect(strlen($hashId))->toBe(64);
     });
 
     it('generateFromValue pads hashId if too short', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $hashId = $generator->generateFromValue('x', null, 1);
         expect(strlen($hashId))->toBe(1);
     });
 
     it('generateFromValue truncates hashId if too long', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $hashId = $generator->generateFromValue('x', null, 64);
         expect(strlen($hashId))->toBe(64);
     });

--- a/tests/MorphsTest.php
+++ b/tests/MorphsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 describe('hashIdMorphs', function () {
@@ -49,12 +50,12 @@ describe('nullableHashIdMorphs', function () {
         });
 
         // Insert a row with null morph values — should not throw
-        \Illuminate\Support\Facades\DB::table('imageables')->insert([
+        DB::table('imageables')->insert([
             'imageable_type' => null,
             'imageable_id' => null,
         ]);
 
-        $row = \Illuminate\Support\Facades\DB::table('imageables')->first();
+        $row = DB::table('imageables')->first();
         expect($row->imageable_type)->toBeNull();
         expect($row->imageable_id)->toBeNull();
     });

--- a/tests/MorphsTest.php
+++ b/tests/MorphsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+describe('hashIdMorphs', function () {
+    it('creates type and id columns with an index', function () {
+        Schema::dropIfExists('taggables');
+        Schema::create('taggables', function ($table) {
+            $table->id();
+            $table->hashIdMorphs('taggable');
+        });
+
+        $columns = Schema::getColumnListing('taggables');
+        expect($columns)->toContain('taggable_type');
+        expect($columns)->toContain('taggable_id');
+    });
+
+    it('supports custom index name', function () {
+        Schema::dropIfExists('commentables');
+        Schema::create('commentables', function ($table) {
+            $table->id();
+            $table->hashIdMorphs('commentable', 'custom_morph_index');
+        });
+
+        $columns = Schema::getColumnListing('commentables');
+        expect($columns)->toContain('commentable_type');
+        expect($columns)->toContain('commentable_id');
+    });
+});
+
+describe('nullableHashIdMorphs', function () {
+    it('creates nullable type and id columns with an index', function () {
+        Schema::dropIfExists('imageables');
+        Schema::create('imageables', function ($table) {
+            $table->id();
+            $table->nullableHashIdMorphs('imageable');
+        });
+
+        $columns = Schema::getColumnListing('imageables');
+        expect($columns)->toContain('imageable_type');
+        expect($columns)->toContain('imageable_id');
+    });
+
+    it('allows null values in morph columns', function () {
+        Schema::dropIfExists('imageables');
+        Schema::create('imageables', function ($table) {
+            $table->id();
+            $table->nullableHashIdMorphs('imageable');
+        });
+
+        // Insert a row with null morph values — should not throw
+        \Illuminate\Support\Facades\DB::table('imageables')->insert([
+            'imageable_type' => null,
+            'imageable_id' => null,
+        ]);
+
+        $row = \Illuminate\Support\Facades\DB::table('imageables')->first();
+        expect($row->imageable_type)->toBeNull();
+        expect($row->imageable_id)->toBeNull();
+    });
+});

--- a/tests/StrMacrosTest.php
+++ b/tests/StrMacrosTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Str;
+
+describe('Str::hashId()', function () {
+    it('generates a 16-character hashId by default', function () {
+        $hashId = Str::hashId();
+        expect($hashId)->toMatch('/^[0-9A-Za-z]{16}$/');
+    });
+
+    it('generates a hashId with custom length', function () {
+        $hashId = Str::hashId(12);
+        expect($hashId)->toMatch('/^[0-9A-Za-z]{12}$/');
+    });
+
+    it('generates unique values', function () {
+        expect(Str::hashId())->not->toBe(Str::hashId());
+    });
+});
+
+describe('Str::isHashId()', function () {
+    it('returns true for valid base62 string', function () {
+        expect(Str::isHashId('Abc123DEFghi4567'))->toBeTrue();
+    });
+
+    it('returns false for non-base62 characters', function () {
+        expect(Str::isHashId('invalid-id!!'))->toBeFalse();
+    });
+
+    it('validates with specific length', function () {
+        $hashId = Str::hashId(16);
+        expect(Str::isHashId($hashId, 16))->toBeTrue();
+        expect(Str::isHashId($hashId, 12))->toBeFalse();
+    });
+});

--- a/tests/TestingFakesTest.php
+++ b/tests/TestingFakesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Bretterer\LaravelHashId\LaravelHashId;
+
+describe('Testing fakes', function () {
+    afterEach(function () {
+        LaravelHashId::createNormally();
+    });
+
+    describe('freeze', function () {
+        it('returns the same hashId on every call', function () {
+            $frozen = LaravelHashId::freeze();
+
+            $generator = new LaravelHashId;
+            expect($generator->generate())->toBe($frozen);
+            expect($generator->generate())->toBe($frozen);
+            expect($generator->generate())->toBe($frozen);
+        });
+
+        it('accepts a callback and resets after', function () {
+            LaravelHashId::freeze(function ($frozen) {
+                $generator = new LaravelHashId;
+                expect($generator->generate())->toBe($frozen);
+            });
+
+            // After callback, generation should be normal (non-frozen)
+            $generator = new LaravelHashId;
+            $a = $generator->generate();
+            $b = $generator->generate();
+            expect($a)->not->toBe($b);
+        });
+
+        it('resets even if callback throws', function () {
+            try {
+                LaravelHashId::freeze(function () {
+                    throw new RuntimeException('test');
+                });
+            } catch (RuntimeException) {
+                // expected
+            }
+
+            $generator = new LaravelHashId;
+            $a = $generator->generate();
+            $b = $generator->generate();
+            expect($a)->not->toBe($b);
+        });
+    });
+
+    describe('createUsing', function () {
+        it('uses custom factory for generation', function () {
+            LaravelHashId::createUsing(fn (int $length) => str_repeat('A', $length));
+
+            $generator = new LaravelHashId;
+            expect($generator->generate(8))->toBe('AAAAAAAA');
+            expect($generator->generate(16))->toBe('AAAAAAAAAAAAAAAA');
+        });
+    });
+
+    describe('createUsingSequence', function () {
+        it('returns values from sequence in order', function () {
+            LaravelHashId::createUsingSequence(['first123456789', 'second12345678', 'third123456789']);
+
+            $generator = new LaravelHashId;
+            expect($generator->generate())->toBe('first123456789');
+            expect($generator->generate())->toBe('second12345678');
+            expect($generator->generate())->toBe('third123456789');
+        });
+
+        it('falls back to normal generation when sequence is exhausted', function () {
+            LaravelHashId::createUsingSequence(['only1234567890']);
+
+            $generator = new LaravelHashId;
+            expect($generator->generate())->toBe('only1234567890');
+
+            // Next call should generate a real hashId
+            $next = $generator->generate(16);
+            expect($next)->toMatch('/^[0-9A-Za-z]{16}$/');
+        });
+
+        it('falls back to whenMissing callback when sequence is exhausted', function () {
+            LaravelHashId::createUsingSequence(
+                ['first123456789'],
+                fn (int $length) => str_repeat('X', $length),
+            );
+
+            $generator = new LaravelHashId;
+            expect($generator->generate())->toBe('first123456789');
+            expect($generator->generate(16))->toBe('XXXXXXXXXXXXXXXX');
+        });
+    });
+
+    describe('createNormally', function () {
+        it('resets all fakes', function () {
+            LaravelHashId::createUsing(fn () => 'fake');
+            LaravelHashId::createNormally();
+
+            $generator = new LaravelHashId;
+            expect($generator->generate(16))->not->toBe('fake');
+            expect($generator->generate(16))->toMatch('/^[0-9A-Za-z]{16}$/');
+        });
+    });
+});

--- a/tests/ValidationRuleTest.php
+++ b/tests/ValidationRuleTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Support\Facades\Validator;
+
+describe('hashid validation rule', function () {
+    it('passes for valid base62 string', function () {
+        $validator = Validator::make(
+            ['id' => 'Abc123DEFghi4567'],
+            ['id' => 'hashid'],
+        );
+
+        expect($validator->passes())->toBeTrue();
+    });
+
+    it('fails for non-base62 characters', function () {
+        $validator = Validator::make(
+            ['id' => 'invalid-id!@#$%^'],
+            ['id' => 'hashid'],
+        );
+
+        expect($validator->fails())->toBeTrue();
+    });
+
+    it('fails for non-string values', function () {
+        $validator = Validator::make(
+            ['id' => 12345],
+            ['id' => 'hashid'],
+        );
+
+        expect($validator->fails())->toBeTrue();
+    });
+
+    it('validates with specific length parameter', function () {
+        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $hashId = $generator->generate(16);
+
+        $validator = Validator::make(
+            ['id' => $hashId],
+            ['id' => 'hashid:16'],
+        );
+
+        expect($validator->passes())->toBeTrue();
+    });
+
+    it('fails when length does not match', function () {
+        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $hashId = $generator->generate(12);
+
+        $validator = Validator::make(
+            ['id' => $hashId],
+            ['id' => 'hashid:16'],
+        );
+
+        expect($validator->fails())->toBeTrue();
+    });
+
+    it('passes without length for any base62 string', function () {
+        $validator = Validator::make(
+            ['id' => 'abc'],
+            ['id' => 'hashid'],
+        );
+
+        expect($validator->passes())->toBeTrue();
+    });
+
+    it('provides correct error message', function () {
+        $validator = Validator::make(
+            ['user_id' => '!!!'],
+            ['user_id' => 'hashid'],
+        );
+
+        $validator->fails();
+        expect($validator->errors()->first('user_id'))->toBe('The user id must be a valid HashId.');
+    });
+});

--- a/tests/ValidationRuleTest.php
+++ b/tests/ValidationRuleTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Bretterer\LaravelHashId\LaravelHashId;
 use Illuminate\Support\Facades\Validator;
 
 describe('hashid validation rule', function () {
@@ -31,7 +32,7 @@ describe('hashid validation rule', function () {
     });
 
     it('validates with specific length parameter', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $hashId = $generator->generate(16);
 
         $validator = Validator::make(
@@ -43,7 +44,7 @@ describe('hashid validation rule', function () {
     });
 
     it('fails when length does not match', function () {
-        $generator = new \Bretterer\LaravelHashId\LaravelHashId;
+        $generator = new LaravelHashId;
         $hashId = $generator->generate(12);
 
         $validator = Validator::make(


### PR DESCRIPTION
## Summary

- **Configurable length**: `hashIdLength()` method on models instead of hardcoded 16
- **Testing fakes**: `freeze()`, `createUsing()`, `createUsingSequence()`, `createNormally()` — mirrors Laravel's `Str::freezeUuids()` pattern
- **Blueprint macros**: `hashIdMorphs()` and `nullableHashIdMorphs()` for polymorphic relationships
- **Validation rule**: `hashid` and `hashid:16` for form requests
- **Str macros**: `Str::hashId()` and `Str::isHashId()` for parity with `Str::uuid()` / `Str::isUuid()`
- **Static helper**: `LaravelHashId::isValid()` for programmatic validation

## Test plan

- [x] All 49 tests passing (81 assertions)
- [x] PHPStan level 5 — 0 errors
- [x] Laravel Pint — all files formatted
- [ ] Verify CI passes on all PHP/Laravel matrix combinations