### PR TITLE
Fix default column length to match generated HashId length

### DIFF
--- a/src/LaravelHashIdServiceProvider.php
+++ b/src/LaravelHashIdServiceProvider.php
@@ -19,9 +19,9 @@ class LaravelHashIdServiceProvider extends ServiceProvider
 
     protected function registerBlueprintMacros(): void
     {
-        Blueprint::macro('hashId', fn (string $column = 'id', int $length = 24): ColumnDefinition => $this->char($column, $length));
+        Blueprint::macro('hashId', fn (string $column = 'id', int $length = 16): ColumnDefinition => $this->char($column, $length));
 
-        Blueprint::macro('foreignHashId', fn (string $column, int $length = 24): ColumnDefinition =>
+        Blueprint::macro('foreignHashId', fn (string $column, int $length = 16): ColumnDefinition =>
             /** @phpstan-ignore-next-line */
             $this->addColumnDefinition(new ForeignIdColumnDefinition($this, [
                 'type' => 'char',
@@ -32,14 +32,14 @@ class LaravelHashIdServiceProvider extends ServiceProvider
         Blueprint::macro('hashIdMorphs', function (string $name, ?string $indexName = null) {
             /** @var Blueprint $this */
             $this->string("{$name}_type");
-            $this->char("{$name}_id", 24);
+            $this->char("{$name}_id", 16);
             $this->index(["{$name}_type", "{$name}_id"], $indexName);
         });
 
         Blueprint::macro('nullableHashIdMorphs', function (string $name, ?string $indexName = null) {
             /** @var Blueprint $this */
             $this->string("{$name}_type")->nullable();
-            $this->char("{$name}_id", 24)->nullable();
+            $this->char("{$name}_id", 16)->nullable();
             $this->index(["{$name}_type", "{$name}_id"], $indexName);
         });
     }


### PR DESCRIPTION
## Summary
- Changed default column length from `CHAR(24)` to `CHAR(16)` in `hashId`, `foreignHashId`, `hashIdMorphs`, and `nullableHashIdMorphs` macros
- The `generate()` method produces 16-character IDs, but columns defaulted to 24 — PostgreSQL pads `CHAR` with spaces causing validation failures and broken lookups
- Consistent with how Laravel's ULID columns match their generated length (`CHAR(26)` for 26-character ULIDs)

## Test plan
- [x] All 49 existing tests pass
- [x] Verify on PostgreSQL that HashId lookups work without trailing space issues